### PR TITLE
fix sending fax, when to is multi-value

### DIFF
--- a/office/v1/client/api_messages.go
+++ b/office/v1/client/api_messages.go
@@ -657,7 +657,9 @@ func (a *MessagesApiService) SendFaxMessage(ctx context.Context, accountId strin
 	if localVarHttpHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
-	localVarFormParams.Add("to", parameterToString(to, "csv"))
+	for _, phone := range to {
+		localVarFormParams.Add("to", phone)
+	}
 	localVarFormFileName = "attachment"
 	var localVarFile *os.File
 	if localVarOptionals != nil && localVarOptionals.Attachment.IsSet() {


### PR DESCRIPTION
Current version works with only one phone number.
if you try to send fax by a few numbers , server returns 400 Bad Request.
My pull request fixes it , and you can send fax by a few numbers